### PR TITLE
Use "stylus" instead of "styl" in code block language tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ or
 
 1. Create your file (or files) with resources :
 
-    ```styl
+    ```stylus
     /* styles/config/mixins.styl */
 
     flexbox($value = row)


### PR DESCRIPTION
This is to silence prism highlighter warnings -- `stylus` is the [officially supported language tag](https://prismjs.com/#languages-list). Thanks!